### PR TITLE
Feature/fix deprecations

### DIFF
--- a/lib/ex_minimatch.ex
+++ b/lib/ex_minimatch.ex
@@ -120,18 +120,21 @@ defmodule ExMinimatch do
   For possible glob patterns and available options, please refer to moduledoc.
   """
   def compile(glob), do: compile(glob, %{})
+
   def compile(glob, options) do
-    options = %{
-      dot: false,
-      nocase: false,
-      match_base: false,
-      nonegate: false,
-      noext: false,
-      noglobstar: false,
-      nocomment: false,
-      nobrace: false,
-      log: nil
-    } |> Dict.merge(options)
+    options =
+      %{
+        dot: false,
+        nocase: false,
+        match_base: false,
+        nonegate: false,
+        noext: false,
+        noglobstar: false,
+        nocomment: false,
+        nobrace: false,
+        log: nil
+      }
+      |> Map.merge(options)
 
     ExMinimatch.Compiler.compile_matcher(glob, options)
   end

--- a/lib/ex_minimatch/compiler.ex
+++ b/lib/ex_minimatch/compiler.ex
@@ -3,13 +3,11 @@ defmodule ExMinimatch.Compiler do
   import ExBraceExpansion
   import ExMinimatch.Helper
 
-  @qmark ExMinimatcher.qmark
-  @globstar ExMinimatcher.globstar
-  @star ExMinimatcher.star
-  @two_star_dot ExMinimatcher.two_star_dot
-  @two_star_no_dot ExMinimatcher.two_star_no_dot
-  @re_specials ExMinimatcher.re_specials
-  @slash_split ExMinimatcher.slash_split
+  @qmark ExMinimatcher.qmark()
+  @globstar ExMinimatcher.globstar()
+  @star ExMinimatcher.star()
+  @re_specials ExMinimatcher.re_specials()
+  @slash_split ExMinimatcher.slash_split()
 
   def compile_matcher(glob, options) do
     {regex_parts_set, negate} = if short_circuit_comments(glob, options) do

--- a/lib/ex_minimatch/compiler.ex
+++ b/lib/ex_minimatch/compiler.ex
@@ -1,5 +1,4 @@
 defmodule ExMinimatch.Compiler do
-  import Dict, only: [merge: 2]
   import ExBraceExpansion
   import ExMinimatch.Helper
 
@@ -151,70 +150,72 @@ defmodule ExMinimatch.Compiler do
 
   def parse(%{c: c, re: re, escaping: escaping} = state) when escaping and c in @re_specials do
     state
-    |> merge(%{
-        re: re <> "\\" <> c,
-        escaping: false
-      })
-    |> continue
+    |> Map.merge(%{
+      re: re <> "\\" <> c,
+      escaping: false
+    })
+    |> continue()
   end
 
-  def parse(%{c: c} = state) when c == "/", do: state |> merge %{failed: true}
+  def parse(%{c: c} = state) when c == "/", do: state |> Map.merge(%{failed: true})
 
   def parse(%{c: c} = state) when c == "\\" do
     state
-    |> clear_state_char
-    |> merge(%{escaping: true})
-    |> continue
+    |> clear_state_char()
+    |> Map.merge(%{escaping: true})
+    |> continue()
   end
 
   def parse(%{c: c, in_class: in_class, i: i, class_start: class_start, re: re} = state) when c in ["?", "*", "+", "@", "!"] and in_class do
     c = if c == "!" and i == class_start + 1, do: "^", else: c
     state
-    |> merge(%{re: re <> c})
-    |> continue
+    |> Map.merge(%{re: re <> c})
+    |> continue()
   end
 
   def parse(%{c: c, options: %{noext: noext}} = state) when c in ["?", "*", "+", "@", "!"] do
     state
     |> clear_state_char
-    |> merge(%{state_char: c})
+    |> Map.merge(%{state_char: c})
     |> transform(fn state -> if noext, do: state |> clear_state_char, else: state end)
     |> continue
   end
 
   def parse(%{c: c, in_class: in_class, re: re} = state) when c == "(" and in_class do
     state
-    |> merge(%{re: re <> "("})
+    |> Map.merge(%{re: re <> "("})
     |> continue
   end
 
   def parse(%{c: c, state_char: state_char, re: re} = state) when c == "(" and state_char == "" do
     state
-    |> merge(%{re: re <> "\\("})
+    |> Map.merge(%{re: re <> "\\("})
     |> continue
   end
 
   def parse(%{c: c, state_char: state_char, pattern_list_stack: pattern_list_stack, re: re, i: i} = state) when c == "(" do
     state
-    |> merge(%{
-        pl_type: state_char,
-        pattern_list_stack: [%{type: state_char, start: i - 1, re_start: len(re)} | pattern_list_stack],
-        re: re <> (if state_char == "!", do: "(?:(?!", else: "(?:"),
-        state_char: ""
-      })
+    |> Map.merge(%{
+      pl_type: state_char,
+      pattern_list_stack: [
+        %{type: state_char, start: i - 1, re_start: len(re)} | pattern_list_stack
+      ],
+      re: re <> if(state_char == "!", do: "(?:(?!", else: "(?:"),
+      state_char: ""
+    })
     |> continue
   end
 
   def parse(%{c: c, in_class: in_class, pattern_list_stack: pattern_list_stack, re: re} = state) when c == ")" and (in_class or length(pattern_list_stack) == 0) do
     state
-    |> merge(%{re: re <> "\\)"})
+    |> Map.merge(%{re: re <> "\\)"})
     |> continue
   end
 
   def parse(%{c: c} = state) when c == ")" do
     state
     |> clear_state_char
-    |> merge(%{has_magic: true})
+    |> Map.merge(%{has_magic: true})
     |> transform(fn %{pattern_list_stack: pattern_list_stack, re: re} = state ->
       new_re = re <> ")"
 
@@ -232,21 +233,21 @@ defmodule ExMinimatch.Compiler do
       end
 
       state
-      |> merge(%{
-          re: new_re,
-          pl_type: new_pl_type,
-          pattern_list_stack: new_pattern_list_stack
-        })
+      |> Map.merge(%{
+        re: new_re,
+        pl_type: new_pl_type,
+        pattern_list_stack: new_pattern_list_stack
+      })
     end)
     |> continue
   end
 
   def parse(%{c: c, in_class: in_class, pattern_list_stack: pattern_list_stack, escaping: escaping, re: re} = state) when c == "|" and (in_class or length(pattern_list_stack) == 0 or escaping) do
     state
-    |> merge(%{
-        re: re <> "\\|",
-        escaping: false
-      })
+    |> Map.merge(%{
+      re: re <> "\\|",
+      escaping: false
+    })
     |> continue
   end
 
@@ -254,9 +255,9 @@ defmodule ExMinimatch.Compiler do
     state
     |> clear_state_char
     |> transform(fn %{re: re} = state ->
-        state
-        |> merge(%{re: re <> "|"})
-      end)
+      state
+      |> Map.merge(%{re: re <> "|"})
+    end)
     |> continue
   end
 
@@ -264,9 +265,9 @@ defmodule ExMinimatch.Compiler do
     state
     |> clear_state_char
     |> transform(fn %{re: re} = state ->
-        state
-        |> merge(%{re: re <> "\\" <> c})
-      end)
+      state
+      |> Map.merge(%{re: re <> "\\" <> c})
+    end)
     |> continue
   end
 
@@ -274,23 +275,23 @@ defmodule ExMinimatch.Compiler do
     state
     |> clear_state_char
     |> transform(fn %{re: re} = state ->
-        state
-        |> merge(%{
-            in_class: true,
-            class_start: i,
-            re_class_start: len(re),
-            re: re <> c
-          })
-      end)
+      state
+      |> Map.merge(%{
+        in_class: true,
+        class_start: i,
+        re_class_start: len(re),
+        re: re <> c
+      })
+    end)
     |> continue
   end
 
   def parse(%{c: c, re: re, in_class: in_class, i: i, class_start: class_start} = state) when c == "]" and (i == class_start + 1 or not in_class) do
     state
-    |> merge(%{
-        re: re <> "\\" <> c,
-        escaping: false
-      })
+    |> Map.merge(%{
+      re: re <> "\\" <> c,
+      escaping: false
+    })
     |> continue
   end
 
@@ -323,7 +324,7 @@ defmodule ExMinimatch.Compiler do
     end
 
     state
-    |> merge(state_changes)
+    |> Map.merge(state_changes)
     |> continue
   end
 
@@ -331,12 +332,12 @@ defmodule ExMinimatch.Compiler do
     state
     |> clear_state_char
     |> transform(fn %{re: re} = state ->
-        state
-        |> merge(%{
-            escaping: false,
-            re: re <> c
-          })
-      end)
+      state
+      |> Map.merge(%{
+        escaping: false,
+        re: re <> c
+      })
+    end)
     |> continue
   end
 
@@ -344,11 +345,11 @@ defmodule ExMinimatch.Compiler do
     state
     |> clear_state_char
     |> transform(fn %{re: re} = state ->
-        state
-        |> merge(%{
-            re: re <> "\\" <> c
-          })
-      end)
+      state
+      |> Map.merge(%{
+        re: re <> "\\" <> c
+      })
+    end)
     |> continue
   end
 
@@ -356,11 +357,11 @@ defmodule ExMinimatch.Compiler do
     state
     |> clear_state_char
     |> transform(fn %{re: re} = state ->
-        state
-        |> merge(%{
-            re: re <> c
-          })
-      end)
+      state
+      |> Map.merge(%{
+        re: re <> c
+      })
+    end)
     |> continue
   end
 
@@ -382,10 +383,10 @@ defmodule ExMinimatch.Compiler do
     {sub_re, sub_has_magic} = parse_glob_to_re(cs, state[:options], true)
 
     state
-    |> merge(%{
-        re: slice(re, 0, re_class_start) <> "\\[" <> sub_re,
-        has_magic: has_magic or sub_has_magic
-      })
+    |> Map.merge(%{
+      re: slice(re, 0, re_class_start) <> "\\[" <> sub_re,
+      has_magic: has_magic or sub_has_magic
+    })
   end
 
   def handle_open_class(state), do: state
@@ -420,11 +421,11 @@ defmodule ExMinimatch.Compiler do
     end
 
     state
-    |> merge(%{
-        has_magic: true,
-        re: slice(re, 0, pl[:re_start]) <> t <> "\\(" <> tail,
-        pattern_list_stack: new_pattern_list_stack
-      })
+    |> Map.merge(%{
+      has_magic: true,
+      re: slice(re, 0, pl[:re_start]) <> t <> "\\(" <> tail,
+      pattern_list_stack: new_pattern_list_stack
+    })
     |> handle_weird_end
   end
 
@@ -438,9 +439,9 @@ defmodule ExMinimatch.Compiler do
 
     state
     |> clear_state_char
-    |> merge(%{
-        re: re <> "\\\\"
-      })
+    |> Map.merge(%{
+      re: re <> "\\\\"
+    })
   end
 
   def handle_trailing_things(state), do: state |> clear_state_char
@@ -458,7 +459,7 @@ defmodule ExMinimatch.Compiler do
     new_re = if add_pattern_start, do: pattern_start <> new_re, else: new_re
 
     state
-    |> merge(%{ re: new_re })
+    |> Map.merge(%{ re: new_re })
   end
 
 
@@ -495,7 +496,8 @@ defmodule ExMinimatch.Compiler do
 
   def clear_state_char(%{state_char: state_char, re: re} = state) do
     state
-    |> merge(case state_char do
+    |> Map.merge(
+      case state_char do
         "*" ->
           %{
             re: re <> @star,
@@ -513,15 +515,16 @@ defmodule ExMinimatch.Compiler do
             re: re <> "\\" <> state_char,
             state_char: ""
           }
-      end)
+      end
+    )
   end
 
   def move_to_next(%{i: i, pattern: pattern} = state) do
     state
-    |> merge(%{
-        i: i + 1,
-        c: at(pattern, i + 1)
-      })
+    |> Map.merge(%{
+      i: i + 1,
+      c: at(pattern, i + 1)
+    })
   end
 
   def continue(state) do

--- a/lib/ex_minimatch/matcher.ex
+++ b/lib/ex_minimatch/matcher.ex
@@ -1,5 +1,4 @@
 defmodule ExMinimatch.Matcher do
-  import Dict, only: [merge: 2]
   import ExMinimatch.Helper
 
   @globstar ExMinimatcher.globstar()
@@ -78,12 +77,12 @@ defmodule ExMinimatch.Matcher do
       false
     else
       state
-      |> merge(%{
-          fi: fi + 1,
-          ri: ri + 1,
-          f: at(file_parts, fi + 1),
-          r: at(regex_parts, ri + 1)
-        })
+      |> Map.merge(%{
+        fi: fi + 1,
+        ri: ri + 1,
+        f: at(file_parts, fi + 1),
+        r: at(regex_parts, ri + 1)
+      })
       |> match_regex_parts
     end
   end

--- a/lib/ex_minimatch/matcher.ex
+++ b/lib/ex_minimatch/matcher.ex
@@ -2,13 +2,8 @@ defmodule ExMinimatch.Matcher do
   import Dict, only: [merge: 2]
   import ExMinimatch.Helper
 
-  @qmark ExMinimatcher.qmark
-  @globstar ExMinimatcher.globstar
-  @star ExMinimatcher.star
-  @two_star_dot ExMinimatcher.two_star_dot
-  @two_star_no_dot ExMinimatcher.two_star_no_dot
-  @re_specials ExMinimatcher.re_specials
-  @slash_split ExMinimatcher.slash_split
+  @globstar ExMinimatcher.globstar()
+  @slash_split ExMinimatcher.slash_split()
 
   def match_file(file, %ExMinimatcher{pattern: regex_parts_set, negate: negate, options: options}) do
     info {"match_file", file, regex_parts_set, negate, options}, options

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,14 @@ defmodule ExMinimatch.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :ex_minimatch,
-     version: "0.0.1",
-     elixir: "~> 1.0",
-     description: description,
-     package: package,
-     deps: deps]
+    [
+      app: :ex_minimatch,
+      version: "0.0.1",
+      elixir: "~> 1.0",
+      description: description(),
+      package: package(),
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Fixes a bunch of deprecation warnings with newer Elixir. Tested with OTP `22` and Elixir `1.10.2`.

The largest of the changes is moving from `Dict.merge/2` to `Map.merge/2`.  I believe this should work, the same tests are failing in this branch as master.

Copy of the deprecations fixed:

```
warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/ex_minimatch/compiler.ex:163

warning: module attribute @re_specials was set but never used
  lib/ex_minimatch/matcher.ex:10

warning: module attribute @two_star_no_dot was set but never used
  lib/ex_minimatch/matcher.ex:9

warning: module attribute @two_star_dot was set but never used
  lib/ex_minimatch/matcher.ex:8

warning: module attribute @star was set but never used
  lib/ex_minimatch/matcher.ex:7

warning: module attribute @qmark was set but never used
  lib/ex_minimatch/matcher.ex:5

warning: module attribute @two_star_no_dot was set but never used
  lib/ex_minimatch/compiler.ex:10

warning: module attribute @two_star_dot was set but never used
  lib/ex_minimatch/compiler.ex:9

warning: Dict.merge/2 is deprecated. Use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/ex_minimatch.ex:134: ExMinimatch.compile/2

warning: Dict.merge/2 is deprecated. Use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/ex_minimatch/matcher.ex:ExMinimatch.Matcher.match_regex_parts/1

warning: Dict.merge/2 is deprecated. Use the Map module for working with maps or the Keyword module for working with keyword lists
Found at 7 locations:
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.clear_state_char/1
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.handle_dot_start/1
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.handle_open_class/1
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.handle_trailing_things/1
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.handle_weird_end/1
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.move_to_next/1
  lib/ex_minimatch/compiler.ex:ExMinimatch.Compiler.parse/1
```